### PR TITLE
DEV: 2026.10 dev bump

### DIFF
--- a/environment-files/readthedocs.yml
+++ b/environment-files/readthedocs.yml
@@ -1,5 +1,5 @@
 channels:
-- https://packages.qiime2.org/qiime2/2026.7/qiime2/passed
+- https://packages.qiime2.org/qiime2/2026.10/qiime2/passed
 - conda-forge
 - bioconda
 dependencies:


### PR DESCRIPTION
Updates the readthedocs build environment to the 2026.10 development (passed) channel.